### PR TITLE
Archived jobs mvp

### DIFF
--- a/app/includes/jobs/inc_archived-jobs-table-mvp.html
+++ b/app/includes/jobs/inc_archived-jobs-table-mvp.html
@@ -1,0 +1,37 @@
+<table id="archived Table" class="govuk-table govuk-table--small-text-until-tablet">
+    <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Job ID</th>
+            <th scope="col" class="govuk-table__header">Annotator</th>
+            <th scope="col" class="govuk-table__header">Assigned on</th>
+            <th scope="col" class="govuk-table__header">Status</th>
+        </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+                <a href="/admin/check-status/titles-list?jobID=1&user=Annotator%201" class="govuk-link">Job 1</a>
+            </td>
+            <td class="govuk-table__cell" id="job1-user">
+                {{ data['AV59722-user'] or "Annotator 1" }}
+            </td>
+            <td class="govuk-table__cell">
+                {% if data['jobID'] == 1 and data['alertType'] == 'reassign-success' %}
+                {{ "now" | govukDateTime }}
+                {% else %}
+                10 Febraury at 9:45am
+                {% endif %}
+            </td>
+            <td class="govuk-table__cell">
+                {% include "app/includes/status-tags/inc_job1-status.html" %}
+            </td>
+            <td class="govuk-table__cell">
+                <ul class="govuk-summary-list__actions-list">
+                    <li class="govuk-summary-list__actions-list-item">
+                        <a class="govuk-link" href="/admin/check-status/reassign-job?jobID=1">Reassign</a>
+                    </li>
+                </ul>
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/app/includes/jobs/inc_jobs-table-mvp.html
+++ b/app/includes/jobs/inc_jobs-table-mvp.html
@@ -5,9 +5,14 @@
             <th scope="col" class="govuk-table__header">Annotator</th>
             <th scope="col" class="govuk-table__header">Assigned on</th>
             <th scope="col" class="govuk-table__header">Status</th>
+            <th scope="col" class="govuk-table__header"></th>
         </tr>
     </thead>
     <tbody class="govuk-table__body">
+        {% if job1Archived == 'yes' %}
+        <tr class="govuk-table__row">
+            </tr>
+        {% else %}
         <tr class="govuk-table__row">
             <td class="govuk-table__cell">
                 <a href="/admin/check-status/titles-list?jobID=1&user=Annotator%201" class="govuk-link">Job 1</a>
@@ -31,14 +36,12 @@
                         <a class="govuk-link" href="/admin/check-status/reassign-job?jobID=1">Reassign</a>
                     </li>
                     <li class="govuk-summary-list__actions-list-item">
-                        {% if job1Archived == 'yes' %}
-                        {% else %}
-                        <a class="govuk-link" href="/admin/check-status/confirm-archive?jobID=1">Archive</a>
-                        {% endif %}
+                        <a class="govuk-link" href="/admin/check-status/confirm-archive-mvp?jobID=1">Archive</a>
                     </li>
                 </ul>
             </td>
         </tr>
+        {% endif %}
         <tr class="govuk-table__row">
             <td class="govuk-table__cell">
                 Job 9

--- a/app/views/admin/check-status/archived-jobs-list-mvp.html
+++ b/app/views/admin/check-status/archived-jobs-list-mvp.html
@@ -16,23 +16,22 @@
 {% block content %}
 
 <main class="govuk-main-wrapper">
-    <h1 class="govuk-heading-l">Active jobs</h1>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            {% include "app/includes/alerts/inc_job-reassign-success.html" %}
-            {% include "app/includes/alerts/inc_job-archive-success.html" %}
-        </div>
-    </div>
+    <h1 class="govuk-heading-l">Archived jobs</h1>
+
+    {% if job1Archived == 'yes' %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-quarter">
             {% include "app/includes/jobs/inc_sort-panel.html" %}
             <hr class="govuk-section-break govuk-section-break--m">
-            <a class="govuk-link" href="/admin/check-status/archived-jobs-list-mvp">View archived jobs</a>
+            <a class="govuk-link" href="/admin/check-status/jobs-list-mvp">View active jobs</a>
         </div>
         <div class="govuk-grid-column-three-quarters">
-            {% include "app/includes/jobs/inc_jobs-table-mvp.html" %}
+            {% include "app/includes/jobs/inc_archived-jobs-table-mvp.html" %}
         </div>
     </div>
+    {% else %}
+    <p class="govuk-body">There are no archived jobs.</p>
+    {% endif %}
 </main>
 
 

--- a/app/views/admin/check-status/confirm-archive-mvp.html
+++ b/app/views/admin/check-status/confirm-archive-mvp.html
@@ -1,0 +1,27 @@
+{% extends "app/views/layouts/hmlr-admin.html" %}
+{% set currentPage="check" %}
+
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% block pageTitle %}
+Unbranded page template – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block content %}
+
+<h1 class="govuk-heading-l">Confirm job to archive</h1>
+
+<form class="form" action="/admin/check-status/jobs-list-mvp?alertType=archive-success" method="post">
+  <div class="govuk-inset-text">
+    <p>Job <strong>{{ data['jobID'] }}</strong> </p>
+    <p>Annotator <strong>{{ data['job1-user'] or "1" }}</strong> </p>
+  </div>
+
+
+{{ govukButton({
+text: "Archive"
+}) }}
+
+</form>
+
+{% endblock %}

--- a/app/views/sort-test.html
+++ b/app/views/sort-test.html
@@ -1,22 +1,13 @@
-{% extends "app/views/layouts/hmlr-admin.html" %}
-{% set currentPage="check" %}
+{% extends "layouts/hmlr-index.html" %}
 
-{% set AV178903Status="started" %}
+{% set pageName="Prototype index" %}
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
-
-{% if data['jobID'] == '1' and data['alertType'] == 'archive-success' %}
-{% set job1Archived = "yes" %}
-{% endif %}
-
-{% block pageTitle %}
-{{ serviceName }} – GOV.UK Prototype Kit
-{% endblock %}
 
 {% block content %}
 
 <main class="govuk-main-wrapper">
-    <h1 class="govuk-heading-l">Active jobs</h1>
+    <h1 class="govuk-heading-l">Jobs</h1>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             {% include "app/includes/alerts/inc_job-reassign-success.html" %}
@@ -26,14 +17,11 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-quarter">
             {% include "app/includes/jobs/inc_sort-panel.html" %}
-            <hr class="govuk-section-break govuk-section-break--m">
-            <a class="govuk-link" href="/admin/check-status/archived-jobs-list-mvp">View archived jobs</a>
         </div>
         <div class="govuk-grid-column-three-quarters">
             {% include "app/includes/jobs/inc_jobs-table-mvp.html" %}
         </div>
     </div>
 </main>
-
 
 {% endblock %}


### PR DESCRIPTION
For MVP an option without filters on the admin jobs list view, we need a way to show or hide archived jobs. This adds a link to the 'Sprint 1 MVP jobs table' to a page for archived jobs with a table for archived jobs only.